### PR TITLE
Add medqa task

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -4,7 +4,7 @@ from typing import List, Union
 import sacrebleu
 import lm_eval.base
 
-from . import babi
+from . import babi, medqa
 from . import superglue
 from . import glue
 from . import arc
@@ -335,6 +335,8 @@ TASK_REGISTRY = {
     "haerae_rc": haerae.RC,
     "haerae_rw": haerae.RW,
     "haerae_sn": haerae.SN,
+    "medqa": medqa.MedQA,
+
     # Requires manual download
     # Requires manual download of data.
     # "storycloze_2016": storycloze.StoryCloze2016,

--- a/lm_eval/tasks/medqa.py
+++ b/lm_eval/tasks/medqa.py
@@ -1,0 +1,73 @@
+"""
+MedQA: A Large-scale Open Domain Question Answering Dataset from Medical Exams
+
+https://arxiv.org/abs/2009.13081
+
+Open domain question answering (OpenQA) tasks have been recently attracting
+more and more attention from the natural language processing (NLP) community.
+In this work, we present the first free-form multiple-choice OpenQA dataset
+for solving medical problems, MedQA, collected from the professional medical
+board exams. It covers three languages: English, simplified Chinese, and traditional
+Chinese, and contains 12,723, 34,251, and 14,123 questions for the three languages,
+respectively. We implement both rule-based and popular neural methods by sequentially
+combining a document retriever and a machine comprehension model. Through experiments,
+we find that even the current best method can only achieve 36.7\%, 42.0\%, and 70.1\%
+of test accuracy on the English, traditional Chinese, and simplified Chinese questions,
+respectively. We expect MedQA to present great challenges to existing OpenQA systems and
+hope that it can serve as a platform to promote much stronger OpenQA models from the NLP
+community in the future.
+
+Homepage: https://github.com/jind11/MedQA
+"""
+from lm_eval.base import MultipleChoiceTask
+
+
+_CITATION = """
+@article{jin2020disease,
+  title={What Disease does this Patient Have? A Large-scale Open Domain Question Answering Dataset from Medical Exams},
+  author={Jin, Di and Pan, Eileen and Oufattole, Nassim and Weng, Wei-Hung and Fang, Hanyi and Szolovits, Peter},
+  journal={arXiv preprint arXiv:2009.13081},
+  year={2020}
+}
+"""
+
+
+class MedQA(MultipleChoiceTask):
+    VERSION = 0
+    # dataset as denoted in HuggingFace `datasets`.
+    DATASET_PATH = "bigbio/med_qa"
+    # `DATASET_PATH`. If there aren't specific subsets you need, leave this as `None`.
+    DATASET_NAME = "med_qa_en_4options_bigbio_qa"
+
+    def has_training_docs(self):
+        return True
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return True
+
+    def training_docs(self):
+        if self._training_docs is None:
+            self._training_docs = list(map(self._process_doc, self.dataset["train"]))
+        return self._training_docs
+
+    def validation_docs(self):
+        if self.has_validation_docs():
+            return map(self._process_doc, self.dataset["validation"])
+
+    def test_docs(self):
+        if self.has_test_docs():
+            return map(self._process_doc, self.dataset["test"])
+
+    def doc_to_text(self, doc):
+        return (
+                "You are a highly intelligent doctor who answers the following multiple choice question correctly.\nOnly write the answer down."
+                + "\n\n**Question:**" + doc["query"] + "\n\n"
+                + ",".join(doc['choices'])
+                + "\n\n**Answer:**"
+        )
+
+    def doc_to_target(self, doc):
+        return " " + doc["choices"][doc["gold"]] + "\n\n"


### PR DESCRIPTION
[Ticket](https://www.notion.so/f445054dafc0460db130dbdeabc9f48a?v=a25fa96e93664c53a0b8134ccca3a82a&p=305fef75045b4001a8a55f81e487b438&pm=s) 

Prompt construction: followed OpenAi evaluation [here](https://github.com/openai/evals/blob/main/evals/registry/data/medmcqa/convert.js)
Tested with `--model gpt3      --model_args engine=text-davinci-003`
Results:
<img width="862" alt="Screenshot 2023-11-14 at 1 55 59 PM" src="https://github.com/proserve/lm-evaluation-harness/assets/22997987/ee96f827-d2a7-4ada-a24e-be313b4f3120">



scored 49 against 50.8 for gpt3.5

cc: @proserve 